### PR TITLE
Updated COTS_priority column to use GBRMPA 2024-2025 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Generates a standardized geopackage file including data from:
   - https://data.gov.au/dataset/ds-dga-51199513-98fa-46e6-b766-8e1e1c896869/details
   - The metadata for the data.gov.au entry states it has been "Updated 16/08/2023"
 - COTS Control prioritization data:
-  - Provided by Dr Samuel Matthews (GBRMPA COTS Control Program) (05/08/2024)
+  - CoTS data provided by GBRMPA under CC BY-NC 4.0 (http://creativecommons.org/licenses/by-nc/4.0)
 - GBRMPA regional management areas:
   - https://geohub-gbrmpa.hub.arcgis.com/datasets/a21bbf8fa08346fabf825a849dfaf3b3_59/explore
 - GBRMPA marine park zones:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Generates a standardized geopackage file including data from:
 - GBRMPA Reef Feature dataset:
   - https://data.gov.au/dataset/ds-dga-51199513-98fa-46e6-b766-8e1e1c896869/details
   - The metadata for the data.gov.au entry states it has been "Updated 16/08/2023"
+- COTS Control prioritization data:
+  - Provided by Dr Samuel Matthews (GBRMPA COTS Control Program) (05/08/2024)
 - GBRMPA regional management areas:
   - https://geohub-gbrmpa.hub.arcgis.com/datasets/a21bbf8fa08346fabf825a849dfaf3b3_59/explore
 - GBRMPA marine park zones:

--- a/data/TargetReefs_202425.csv
+++ b/data/TargetReefs_202425.csv
@@ -1,0 +1,201 @@
+﻿MgmtAreaShort,ReefName,ReefID,Provider,Longitude,Latitude,MCDA Ranking,RankForAction,Zone
+Far Northern,U/N Reef (10-299),10-299,TBC,143.09,-10.775,7,Rank 2,Habitat Protection
+Far Northern,U/N Reef (10-351),10-351,TBC,143.19,-10.732,10,Rank 3,Habitat Protection
+Far Northern,U/N Reef (10-353),10-353,TBC,143.094,-10.752,6,Rank 1,Habitat Protection|General Use
+Far Northern,U/N Reef (10-372),10-372,TBC,143.157,-10.95,9,Rank 3,Habitat Protection
+Far Northern,McSweeney Reef (11-016),11-016,TBC,143.243,-11.023,8,Rank 2,Habitat Protection
+Far Northern,Monsoon Reef (11-029),11-029,TBC,143.253,-11.129,3,Rank 1,Habitat Protection|General Use
+Far Northern,Collette Reef (11-037),11-037,TBC,143.318,-11.215,4,Rank 2,Habitat Protection|General Use
+Far Northern,U/N Reef (11-039),11-039,TBC,143.257,-11.241,2,Rank 2,Habitat Protection
+Far Northern,U/N Reef (11-049),11-049,TBC,143.335,-11.361,5,Rank 2,Marine National Park
+Far Northern,U/N Reef (11-162),11-162,TBC,143.291,-11.604,1,Rank 3,Marine National Park
+Northern,MacGillivray Reef (14-114),14-114,INLOC/BPM,145.491,-14.652,60,Rank 2,Scientific Research
+Northern,Lizard Island Reef (North West) (14-116a),14-116a,INLOC/BPM,145.447,-14.659,36,Rank 1,Scientific Research|Marine National Park
+Northern,Lizard Island Reef (North East) (14-116b),14-116b,INLOC/BPM,145.466,-14.655,71,Rank 1,Scientific Research|Conservation Park|Marine National Park
+Northern,Lizard Island Reef (Coconut Bay) (14-116c),14-116c,INLOC/BPM,145.472,-14.681,66,Rank 1,Scientific Research
+Northern,Lizard Island Reef (Lagoon) (14-116d),14-116d,INLOC/BPM,145.45,-14.686,63,Rank 1,Scientific Research
+Northern,Eyrie Reef (14-118),14-118,INLOC/BPM,145.379,-14.711,33,Rank 1,Marine National Park
+Northern,Martin Reef (14-123),14-123,INLOC/BPM,145.356,-14.763,43,Rank 1,Habitat Protection
+Northern,Linnet Reef (14-126),14-126,INLOC/BPM,145.344,-14.787,8,Rank 1,Habitat Protection
+Northern,Rocky Islets Reef (14-132a),14-132a,INLOC/BPM,145.48,-14.855,13,Rank 1,Marine National Park
+Northern,U/N Reef (14-132b),14-132b,INLOC/BPM,145.528,-14.866,15,Rank 2,Habitat Protection
+Northern,U/N Reef (14-132c),14-132c,INLOC/BPM,145.489,-14.869,14,Rank 2,Marine National Park
+Northern,U/N Reef (14-133),14-133,INLOC/BPM,145.516,-14.917,16,Rank 1,Habitat Protection
+Northern,Helsdon Reef (14-135),14-135,INLOC/BPM,145.488,-14.939,46,Rank 1,Habitat Protection
+Northern,U/N Reef (14-142),14-142,INLOC/BPM,145.583,-14.731,47,Rank 2,Habitat Protection
+Northern,North Direction Reef (14-143),14-143,INLOC/BPM,145.511,-14.746,7,Rank 2,Scientific Research
+Northern,U/N Reef (14-145),14-145,INLOC/BPM,145.587,-14.79,12,Rank 2,Habitat Protection
+Northern,South Direction Reef (North) (14-147a),14-147a,INLOC/BPM,145.524,-14.824,54,Rank 3,Marine National Park|Buffer
+Northern,South Direction Reef (South) (14-147b),14-147b,INLOC/BPM,145.521,-14.812,11,Rank 2,Buffer
+Northern,U/N Reef (14-149),14-149,INLOC/BPM,145.618,-14.843,78,Rank 2,Habitat Protection
+Northern,Forrester Reef (15-009),15-009,INLOC/BPM,145.496,-15.167,59,Rank 1,Habitat Protection
+Northern,Boulder Reef (15-012),15-012,INLOC/BPM,145.431,-15.414,4,Rank 3,Conservation Park
+Northern,Egret Reef (15-013),15-013,INLOC/BPM,145.417,-15.474,61,Rank 3,Conservation Park
+Northern,Long Reef (15-019),15-019,INLOC/BPM,145.57,-15.051,72,Rank 1,Habitat Protection
+Northern,U/N Reef (15-022),15-022,INLOC/BPM,145.636,-15.098,55,Rank 2,Habitat Protection
+Northern,U/N Reef (15-023),15-023,INLOC/BPM,145.67,-15.094,10,Rank 2,Habitat Protection
+Northern,Mackay Reefs (15-024),15-024,INLOC/BPM,145.571,-15.139,65,Rank 3,Habitat Protection
+Northern,Marx Reef (15-027),15-027,INLOC/BPM,145.621,-15.198,9,Rank 2,Habitat Protection
+Northern,Startle Reefs (15-028),15-028,INLOC/BPM,145.557,-15.207,41,Rank 1,Habitat Protection
+Northern,Swinger Reef (15-030),15-030,INLOC,145.537,-15.242,68,Rank 2,Habitat Protection
+Northern,Pullen Reefs (15-031),15-031,INLOC,145.587,-15.251,76,Rank 2,Habitat Protection
+Northern,Lark Reef (15-033),15-033,INLOC,145.574,-15.288,73,Rank 2,Marine National Park
+Northern,U/N Reef (15-043),15-043,INLOC,145.508,-15.429,75,Rank 2,Habitat Protection
+Northern,U/N Reef (15-048),15-048,INLOC,145.655,-15.484,77,Rank 2,Habitat Protection
+Northern,U/N Reef (15-049),15-049,INLOC,145.503,-15.486,70,Rank 2,Habitat Protection
+Northern,Vicki Harriott Reef (15-070),15-070,INLOC,145.618,-15.503,64,Rank 3,Habitat Protection
+Northern,U/N Reef (15-071c),15-071c,INLOC,145.57,-15.51,79,Rank 2,Habitat Protection
+Northern,Osterlund Reef (15-078),15-078,INLOC,145.532,-15.556,62,Rank 1,Habitat Protection
+Northern,Rosser Reef (15-081),15-081,INLOC,145.515,-15.607,5,Rank 2,Habitat Protection
+Northern,Emily Reef (15-082),15-082,INLOC,145.626,-15.606,69,Rank 2,Habitat Protection
+Northern,Irene Reef (15-084),15-084,INLOC,145.715,-15.648,2,Rank 2,Habitat Protection
+Northern,Cairns Reef (15-086),15-086,INLOC,145.509,-15.672,56,Rank 1,Habitat Protection
+Northern,Ruby Reef (15-088),15-088,INLOC,145.781,-15.75,58,Rank 2,Habitat Protection
+Northern,Endeavour Reef (15-089),15-089,INLOC,145.582,-15.777,67,Rank 3,Marine National Park
+Northern,Pickersgill Reef (15-093),15-093,INLOC,145.574,-15.873,3,Rank 2,Conservation Park
+Northern,Evening Reef (15-095),15-095,INLOC,145.657,-15.905,6,Rank 2,Habitat Protection
+Northern,Agincourt Reefs (No 2b) (15-099e),15-099e,INLOC,145.858,-16.03,1,Rank 3,Marine National Park
+Northern,Spitfire Reefs (East) (16-012b),16-012b,INLOC/BPM,145.635,-16.015,74,Rank 2,Habitat Protection
+Northern,Mackay Reef (16-015),16-015,INLOC,145.647,-16.049,35,Rank 3,Habitat Protection
+Northern,U/N Reef (16-016),16-016,INLOC/BPM,145.739,-16.055,24,Rank 2,Habitat Protection
+Northern,Sylvan Reef (16-017),16-017,INLOC/BPM,145.721,-16.08,22,Rank 2,Habitat Protection
+Northern,U/N Reef (16-018a),16-018a,INLOC/BPM,145.756,-16.077,25,Rank 2,Habitat Protection
+Northern,St Crispin Reef (16-019),16-019,INLOC,145.833,-16.104,42,Rank 3,Habitat Protection
+Northern,Undine Reef (West) (16-020a),16-020a,INLOC,145.687,-16.123,45,Rank 3,Habitat Protection
+Northern,Undine Reef (East) (16-020b),16-020b,INLOC,145.775,-16.117,57,Rank 3,Habitat Protection
+Northern,Rudder Reef (16-023),16-023,INLOC,145.693,-16.192,39,Rank 2,Habitat Protection
+Northern,Chinaman Reef (16-024),16-024,INLOC,145.792,-16.213,44,Rank 3,Habitat Protection
+Northern,Opal Reef (16-025),16-025,INLOC,145.89,-16.221,31,Rank 1,Marine National Park|Conservation Park
+Northern,Tongue Reef (16-026),16-026,INLOC/BPM,145.793,-16.321,34,Rank 3,Marine National Park|Habitat Protection
+Northern,Low Islands Reef (16-028),16-028,INLOC,145.564,-16.386,27,Rank 3,Commonwealth Island (GBRMPA)|Marine National Park
+Northern,Batt Reef (16-029),16-029,INLOC/BPM,145.767,-16.414,17,Rank 1,Habitat Protection
+Northern,Norman Reef (16-030),16-030,INLOC,145.997,-16.428,23,Rank 3,Marine National Park
+Northern,Saxon Reef (16-032),16-032,INLOC,145.99,-16.465,21,Rank 2,Marine National Park
+Northern,Pixie Reef (16-040),16-040,INLOC,145.862,-16.547,18,Rank 1,Habitat Protection
+Northern,Breaking Patches (16-042),16-042,INLOC,145.98,-16.582,53,Rank 3,Marine National Park
+Northern,Green Island Reef (16-049),16-049,INLOC,145.999,-16.767,19,Rank 3,Scientific Research|Marine National Park|Habitat Protection
+Northern,Fitzroy Island Reef (No 1) (16-054a),16-054a,INLOC,145.994,-16.925,38,Rank 3,Conservation Park
+Northern,Fitzroy Island Reef (No 2) (16-054b),16-054b,INLOC,145.985,-16.933,52,Rank 3,Conservation Park
+Northern,U/N Reef (16-054f),16-054f,INLOC,145.989,-16.941,49,Rank 3,Conservation Park
+Northern,U/N Reef (16-054g),16-054g,INLOC,146.002,-16.934,51,Rank 3,Conservation Park
+Northern,Little Fitzroy Island Reef (16-055),16-055,INLOC,146.006,-16.923,50,Rank 3,Conservation Park|Commonwealth Island (Other)
+Northern,Hastings Reef (16-057),16-057,INLOC,146.008,-16.518,26,Rank 3,Marine National Park
+Northern,Michaelmas Reef (16-060),16-060,INLOC,146.019,-16.582,32,Rank 1,Marine National Park
+Northern,Arlington Reef (16-064),16-064,INLOC,146.055,-16.695,30,Rank 3,Conservation Park|Habitat Protection
+Northern,Milln Reef (16-067),16-067,INLOC,146.265,-16.778,28,Rank 3,Marine National Park|Habitat Protection|General Use
+Northern,Thetford Reef (16-068),16-068,INLOC,146.181,-16.803,29,Rank 3,Conservation Park
+Northern,Moore Reef (16-071),16-071,INLOC,146.213,-16.874,37,Rank 3,Marine National Park|Habitat Protection
+Northern,Briggs Reef (16-074),16-074,INLOC,146.207,-16.938,20,Rank 1,Marine National Park
+Northern,Normanby-Mabel Reef (17-012),17-012,INLOC,146.077,-17.21,40,Rank 3,Marine National Park|Conservation Park
+Northern,Round-Russell Reef (17-013),17-013,INLOC,146.092,-17.224,48,Rank 1,Conservation Park|Commonwealth Island (GBRMPA)
+Northern,Potter Reef (No 1) (17-059a),17-059a,INLOC,146.544,-17.698,80,Rank 2,Habitat Protection
+Central,Reg Ward Reef (18-017),18-017,INLOC,146.785,-18.032,13,Rank 1,Marine National Park
+Central,Barnett Patches (18-019),18-019,INLOC,146.853,-18.06,44,Rank 1,Marine National Park
+Central,Britomart Reef (18-024),18-024,INLOC,146.726,-18.229,40,Rank 1,General Use|Habitat Protection
+Central,Trunk Reef (18-027),18-027,INLOC,146.832,-18.354,42,Rank 1,Conservation Park
+Central,Kelso Reef (18-030),18-030,INLOC,146.99,-18.436,38,Rank 1,Marine National Park|General Use
+Central,Little Kelso Reef (18-031),18-031,INLOC,146.993,-18.469,5,Rank 3,Marine National Park
+Central,Pith Reef (18-033),18-033,INLOC,147.016,-18.209,43,Rank 3,Habitat Protection
+Central,Arab Reef (18-040),18-040,INLOC,147.139,-18.415,60,Rank 2,Habitat Protection
+Central,Fore And Aft Reef (18-043),18-043,INLOC,147.038,-18.505,30,Rank 2,Habitat Protection
+Central,Backnumbers Reef (18-069a),18-069a,INLOC,147.148,-18.509,50,Rank 1,Habitat Protection
+Central,Hopkinson Reef (18-073),18-073,INLOC,147.193,-18.551,23,Rank 1,Habitat Protection
+Central,Yankee Reef (18-074),18-074,INLOC,147.499,-18.561,57,Rank 2,Marine National Park
+Central,John Brewer Reef (18-075),18-075,PMG,147.053,-18.631,25,Rank 1,General Use|Conservation Park
+Central,Helix Reef (18-076),18-076,PMG,147.298,-18.625,46,Rank 1,Marine National Park
+Central,Grub Reef (18-077),18-077,INLOC,147.426,-18.626,48,Rank 2,Habitat Protection
+Central,Lodestone Reef (18-078),18-078,PMG,147.103,-18.69,36,Rank 3,Habitat Protection
+Central,Keeper Reef (18-079),18-079,PMG,147.268,-18.746,32,Rank 2,Habitat Protection
+Central,Knife Reef (18-081),18-081,INLOC,147.571,-18.576,55,Rank 2,Marine National Park
+Central,Fork Reef (18-083),18-083,INLOC,147.554,-18.608,11,Rank 2,Marine National Park
+Central,Anzac Reefs (No 1) (18-087),18-087,INLOC,147.857,-18.694,51,Rank 2,Marine National Park
+Central,Centipede Reef (18-088),18-088,INLOC,147.542,-18.722,56,Rank 2,Habitat Protection
+Central,Anzac Reefs (No 3) (18-090),18-090,INLOC,147.842,-18.731,53,Rank 2,Marine National Park
+Central,Lynchs Reef (18-091),18-091,INLOC,147.708,-18.77,35,Rank 1,Marine National Park
+Central,Wheeler Reef (18-095),18-095,PMG,147.526,-18.798,21,Rank 1,Marine National Park
+Central,Davies Reef (18-096),18-096,PMG,147.645,-18.822,22,Rank 1,Conservation Park
+Central,Saville-Kent Reef (18-099),18-099,PMG,147.883,-18.859,47,Rank 2,Marine National Park
+Central,(Big) Broadhurst Reef (No 1) (18-100a),18-100a,INLOC,147.742,-18.907,28,Rank 1,General Use|Habitat Protection
+Central,(Big) Broadhurst Reef (No 2) (18-100b),18-100b,INLOC,147.694,-18.863,41,Rank 2,Habitat Protection
+Central,Judith Wright Reef (18-101),18-101,PMG,147.951,-18.9,31,Rank 1,Marine National Park|Habitat Protection
+Central,U/N Reef (18-103),18-103,PMG,147.892,-18.906,14,Rank 1,Habitat Protection
+Central,Banfield Reef (North) (18-105a),18-105a,PMG,147.897,-18.925,49,Rank 1,Habitat Protection
+Central,Banfield Reef (South) (18-105b),18-105b,PMG,147.909,-18.939,6,Rank 3,Habitat Protection
+Central,(Little) Broadhurst Reef (18-106),18-106,INLOC,147.694,-18.956,26,Rank 3,General Use|Habitat Protection
+Central,Viper Reef (18-112),18-112,PMG,148.151,-18.873,52,Rank 3,Habitat Protection
+Central,Jupiter Reef (18-115),18-115,PMG,148.253,-18.924,3,Rank 2,Habitat Protection
+Central,Shrimp Reef (18-118),18-118,PMG,148.053,-18.969,58,Rank 3,Habitat Protection|General Use
+Central,Bowden Reef (19-019),19-019,PMG,147.928,-19.033,54,Rank 1,Habitat Protection|General Use
+Central,Prawn Reef (19-024),19-024,PMG,148.097,-19.021,1,Rank 2,Habitat Protection
+Central,Castor Reef (19-025),19-025,PMG,148.341,-19.015,2,Rank 2,Habitat Protection
+Central,Shell Reef (19-028),19-028,PMG,148.182,-19.059,7,Rank 2,Habitat Protection
+Central,U/N Reef (19-039),19-039,PMG,148.189,-19.122,12,Rank 2,Habitat Protection
+Central,U/N Reef (19-040),19-040,PMG,148.18,-19.132,9,Rank 2,Habitat Protection
+Central,Darley Reef (19-043),19-043,PMG,148.183,-19.197,33,Rank 1,Habitat Protection
+Central,Faith Reef (19-044),19-044,PMG,148.35,-19.279,16,Rank 3,Habitat Protection|General Use
+Central,Tiger Reef (19-054),19-054,PMG,148.549,-19.201,8,Rank 2,Marine National Park
+Central,Elizabeth Reef (19-082),19-082,PMG,149.043,-19.326,59,Rank 2,Habitat Protection
+Central,Block Reef (19-127),19-127,PMG,149.373,-19.699,24,Rank 1,Habitat Protection
+Central,U/N Reef (19-131a),19-131a,PMG,149.368,-19.761,20,Rank 2,Habitat Protection
+Central,Circular Quay Reef (19-134),19-134,PMG,149.486,-19.744,39,Rank 1,Habitat Protection
+Central,Hardy Reef (19-135),19-135,PMG,149.233,-19.76,27,Rank 1,Marine National Park
+Central,Hook Reef (19-136a),19-136a,PMG,149.185,-19.792,34,Rank 3,Conservation Park|Marine National Park
+Central,Bait Reef (19-137),19-137,PMG,149.074,-19.807,29,Rank 2,Marine National Park
+Central,U/N Reef (19-138),19-138,PMG,149.425,-19.801,19,Rank 2,Habitat Protection
+Central,Hayman Island Reef (20-014),20-014,PMG,148.891,-20.061,45,Rank 3,Marine National Park|Conservation Park|Habitat Protection
+Central,Black Island Reef (20-017),20-017,PMG,148.893,-20.081,37,Rank 3,Marine National Park|Conservation Park
+Central,Langford-Bird Reef (20-019),20-019,PMG,148.878,-20.088,4,Rank 3,Marine National Park|Conservation Park
+Central,Hook Island Reef (No 6) (20-028f),20-028f,PMG,148.908,-20.077,10,Rank 2,Marine National Park|Conservation Park
+Central,Hook Island Reef (No 7) (20-028g),20-028g,PMG,148.925,-20.073,15,Rank 3,Marine National Park
+Central,Hook Island Reef (No 9) (20-028h),20-028h,PMG,148.958,-20.063,18,Rank 3,Marine National Park|Habitat Protection
+Central,Hook Island Reef (No 8) (20-028j),20-028j,PMG,148.939,-20.067,17,Rank 3,Marine National Park
+Southern,Tern Reef (20-309),20-309,BPM,150.033,-20.909,13,Rank 2,Marine National Park
+Southern,Bushy-Redbill Reef (20-310),20-310,BPM,150.08,-20.962,22,Rank 2,Marine National Park
+Southern,U/N Reef (21-057),21-057,BPM,150.481,-21.123,46,Rank 1,Habitat Protection
+Southern,U/N Reef (21-181),21-181,BPM,151.858,-21.371,50,Rank 2,Habitat Protection
+Southern,U/N Reef (21-186),21-186,BPM,151.793,-21.411,3,Rank 2,Habitat Protection
+Southern,U/N Reef (21-187),21-187,BPM,151.648,-21.419,1,Rank 2,Habitat Protection
+Southern,U/N Reef (21-188),21-188,BPM,151.586,-21.444,2,Rank 2,Habitat Protection
+Southern,U/N Reef (21-438),21-438,BPM,151.812,-21.516,47,Rank 2,Habitat Protection
+Southern,U/N Reef (21-441),21-441,BPM,151.775,-21.527,48,Rank 2,Habitat Protection
+Southern,U/N Reef (21-454),21-454,BPM,151.968,-21.766,9,Rank 2,Habitat Protection|General Use
+Southern,U/N Reef (21-460),21-460,BPM,151.742,-21.711,33,Rank 2,Habitat Protection
+Southern,U/N Reef (21-464),21-464,BPM,151.774,-21.756,28,Rank 2,Habitat Protection
+Southern,U/N Reef (21-465),21-465,BPM,151.882,-21.804,27,Rank 1,Habitat Protection|General Use
+Southern,U/N Reef (21-466),21-466,BPM,151.987,-21.838,35,Rank 2,Habitat Protection|General Use
+Southern,U/N Reef (21-467),21-467,BPM,151.926,-21.887,44,Rank 2,Habitat Protection|General Use
+Southern,Snake Reef (21-088a),21-088a,BPM,152.16,-22.03,10,Rank 1,Marine National Park
+Southern,U/N Reef (21-499),21-499,BPM,152.452,-21.664,5,Rank 1,Marine National Park
+Southern,U/N Reef (21-500),21-500,BPM,152.394,-21.674,49,Rank 2,Habitat Protection
+Southern,Recreation Reef (21-501),21-501,BPM,152.441,-21.678,11,Rank 1,Marine National Park
+Southern,U/N Reef (21-502),21-502,BPM,152.498,-21.675,20,Rank 2,Marine National Park
+Southern,Isobel Bennett Reef (21-505),21-505,BPM,152.349,-21.707,4,Rank 3,Habitat Protection
+Southern,U/N Reef (21-509),21-509,BPM,152.387,-21.728,15,Rank 3,Marine National Park
+Southern,U/N Reef (21-512),21-512,BPM,152.335,-21.758,43,Rank 3,Marine National Park
+Southern,Detour Reef (21-514),21-514,BPM,152.415,-21.761,8,Rank 1,Marine National Park
+Southern,Small Reef (21-517),21-517,BPM,152.424,-21.776,6,Rank 3,Marine National Park
+Southern,Houdini Reef (21-524),21-524,BPM,152.428,-21.823,17,Rank 2,Marine National Park
+Southern,U/N Reef (21-525),21-525,BPM,152.459,-21.823,12,Rank 1,Marine National Park
+Southern,U/N Reef (21-526),21-526,BPM,152.312,-21.832,18,Rank 1,Marine National Park
+Southern,U/N Reef (21-532),21-532,BPM,152.354,-21.863,45,Rank 3,Marine National Park
+Southern,Emperor Reef (21-538),21-538,BPM,152.444,-21.884,23,Rank 1,Habitat Protection
+Southern,U/N Reef (21-539),21-539,BPM,152.271,-21.94,21,Rank 2,Marine National Park|Habitat Protection
+Southern,U/N Reef (21-544),21-544,BPM,152.109,-21.922,42,Rank 3,Marine National Park
+Southern,Poulson Reef (21-548),21-548,BPM,152.459,-21.936,7,Rank 3,Habitat Protection
+Southern,Pike Reef (21-549),21-549,BPM,152.423,-21.948,29,Rank 3,Habitat Protection
+Southern,U/N Reef (21-551),21-551,BPM,152.056,-21.961,40,Rank 1,Marine National Park|General Use
+Southern,U/N Reef (21-553),21-553,BPM,152.347,-21.976,36,Rank 3,Habitat Protection
+Southern,U/N Reef (21-554),21-554,BPM,152.375,-21.98,32,Rank 3,Habitat Protection
+Southern,U/N Reef (21-558),21-558,BPM,152.546,-21.549,16,Rank 1,Marine National Park
+Southern,U/N Reef (21-559),21-559,BPM,152.534,-21.573,14,Rank 2,Marine National Park
+Southern,Wilson Island Reef (23-050),23-050,BPM,151.89,-23.291,19,Rank 1,Marine National Park|Conservation Park
+Southern,Heron Reef (23-052a),23-052a,BPM,151.971,-23.446,24,Rank 2,Marine National Park|Scientific Research|Conservation Park
+Southern,Sykes Reef (23-054),23-054,BPM,152.034,-23.433,30,Rank 1,Conservation Park
+Southern,Lamont Reef (23-076),23-076,BPM,152.027,-23.599,26,Rank 1,Habitat Protection|General Use
+Southern,Fitzroy Reef (23-077),23-077,BPM,152.147,-23.633,34,Rank 2,Habitat Protection
+Southern,Llewellyn Reef (23-078),23-078,BPM,152.181,-23.695,37,Rank 2,Marine National Park
+Southern,Boult Reef (23-079),23-079,BPM,152.272,-23.757,31,Rank 2,Habitat Protection
+Southern,Hoskyn Islands Reef (23-080),23-080,BPM,152.287,-23.808,41,Rank 2,Marine National Park
+Southern,Fairfax Islands Reef (23-081),23-081,BPM,152.361,-23.867,38,Rank 2,Marine National Park
+Southern,Lady Musgrave Reef (23-082a),23-082a,BPM,152.387,-23.902,25,Rank 1,Marine National Park|Habitat Protection|General Use
+Southern,Lady Elliot Island Reef (24-008),24-008,BPM,152.715,-24.113,39,Rank 3,Marine National Park|Commonwealth Island (GBRMPA)

--- a/src/1_create_canonical.jl
+++ b/src/1_create_canonical.jl
@@ -63,10 +63,13 @@ gbr_matched = vcat(gbr_matched, gbr_features[gbr_features.LABEL_ID.∈Ref(values
 updated_idx = rme_features.LABEL_ID .∈ Ref(keys(updated_ID_mapping))
 updated_reefs_rme_ids = rme_features[updated_idx, :UNIQUE_ID]
 
+old_LABEL_IDs = vcat(gbr_features[matching_reefs, :LABEL_ID], rme_features[updated_idx, :LABEL_ID])
+RME_LABEL_IDs = ifelse.(old_LABEL_IDs .== "20198", "20-198", old_LABEL_IDs)
+
 old_UNIQUE_IDs = vcat(matching_UNIQUE_IDs, updated_reefs_rme_ids)
 
 gbr_matched[!, :RME_UNIQUE_ID] = old_UNIQUE_IDs
-gbr_matched[!, :RME_GBRMPA_ID] = rme_ids.reef_id
+gbr_matched[!, :RME_GBRMPA_ID] = RME_LABEL_IDs
 
 # Start copying relevant columns
 cols_of_interest = [:UNIQUE_ID, :LABEL_ID, :X_LABEL, :LOC_NAME_S, :RME_UNIQUE_ID, :RME_GBRMPA_ID]

--- a/src/2_add_cots_priority.jl
+++ b/src/2_add_cots_priority.jl
@@ -3,44 +3,38 @@ include("common.jl")
 # Load required data.
 canonical_file = find_latest_file(OUTPUT_DIR)
 RRAP_lookup = GDF.read(canonical_file)
-cots_priority = CSV.read(joinpath(DATA_DIR, "CoCoNet_CoTS_control_reefs_2024.csv"), DataFrame, missingstring="NA")
+cots_priority = CSV.read(joinpath(DATA_DIR, "TargetReefs_202425.csv"), DataFrame)
 
-# Temporarily fix incorrect GBRMPA_ID to match
-RRAP_lookup.COTS_GBRMPA_ID = ifelse.(RRAP_lookup.GBRMPA_ID .== "20198", "20-198", RRAP_lookup.GBRMPA_ID)
-
-# Format data.
+# Format input data.
 rename!(
     cots_priority,
     Dict(
-        "LAT"=>:cots_LAT,
-        "LON"=>:cots_LON,
-        "ReefID"=>:COTS_GBRMPA_ID,
-        "Priority"=>:priority
+        "Latitude"=>:cots_LAT,
+        "Longitude"=>:cots_LON,
+        "ReefID"=>:GBRMPA_ID,
+        "RankForAction"=>:priority
         )
     )
-cots_priority = cots_priority[:, [:COTS_GBRMPA_ID, :cots_LON, :cots_LAT, :priority]]
+cots_priority = cots_priority[:, [:GBRMPA_ID, :cots_LON, :cots_LAT, :priority]]
 
 # Adding cots priority into RRAP_lookup.
-RRAP_lookup = leftjoin(RRAP_lookup, cots_priority, on=:COTS_GBRMPA_ID, order=:left)
+RRAP_lookup = leftjoin(RRAP_lookup, cots_priority, on=:GBRMPA_ID, order=:left)
 
-# Cross-checking that the GBRMPA_ID from RRAP_lookup matches from cots_priority (within 100m - rounded values).
+# Cross-checking that the GBRMPA_ID from RRAP_lookup matches from cots_priority (within 500m - rounded values).
 matching = DataFrame(match_lon=[], match_lat=[])
-match_lon = (RRAP_lookup.cots_LON .< RRAP_lookup.LON .+ 0.001) .& (RRAP_lookup.cots_LON .> RRAP_lookup.LON .- 0.001)
-match_lat = (RRAP_lookup.cots_LAT .< RRAP_lookup.LAT .+ 0.001) .& (RRAP_lookup.cots_LAT .> RRAP_lookup.LAT .- 0.001)
+match_lon = (RRAP_lookup.cots_LON .< RRAP_lookup.LON .+ 0.005) .& (RRAP_lookup.cots_LON .> RRAP_lookup.LON .- 0.005)
+match_lat = (RRAP_lookup.cots_LAT .< RRAP_lookup.LAT .+ 0.005) .& (RRAP_lookup.cots_LAT .> RRAP_lookup.LAT .- 0.005)
 matching = DataFrame(match_lon=match_lon, match_lat=match_lat)
-spat_mismatch = RRAP_lookup[(findall(skipmissing(.!matching.match_lon))),:]
-
-# Visual check of how close mismatching coords are to original coords.
-reef_plot, ga = plot_map(spat_mismatch)
-scatter!(ga, spat_mismatch.LON, spat_mismatch.LAT, markersize = 8)
-scatter!(ga, spat_mismatch.cots_LON, spat_mismatch.LAT, markersize = 6)
-save(joinpath(FIGS_DIR, "rrap_cots_data_mismatching_locations_$(today()).png"), reef_plot)
+spat_mismatch = RRAP_lookup[(findall(skipmissing(.!matching.match_lon))),:] # With updated GBRMPA data all locations match
 
 # Format output data.
 RRAP_lookup = select!(RRAP_lookup, Not(:cots_LON, :cots_LAT))
 rename!(RRAP_lookup, Dict(:priority=>:COTS_priority))
 RRAP_lookup.COTS_priority .= ifelse.(ismissing.(RRAP_lookup.COTS_priority), "NA", RRAP_lookup.COTS_priority)
+RRAP_lookup.COTS_priority .= ifelse.(RRAP_lookup.COTS_priority .== "Rank 1", "T", RRAP_lookup.COTS_priority)
+RRAP_lookup.COTS_priority .= ifelse.(RRAP_lookup.COTS_priority .== "Rank 2", "P", RRAP_lookup.COTS_priority)
+RRAP_lookup.COTS_priority .= ifelse.(RRAP_lookup.COTS_priority .== "Rank 3", "N", RRAP_lookup.COTS_priority)
 RRAP_lookup.COTS_priority = convert.(String, RRAP_lookup.COTS_priority)
 
 # Replace canonical file with updated data
-GDF.write(canonical_file, select(RRAP_lookup, Not(:COTS_GBRMPA_ID)); crs=GBRMPA_CRS)
+GDF.write(canonical_file, RRAP_lookup; crs=GBRMPA_CRS)


### PR DESCRIPTION
Replaced the older CoCoNet COTS_priority data with updated data from GBRMPA for 2024/25 year.